### PR TITLE
Preparations for XInitThreads

### DIFF
--- a/src/c/common.h
+++ b/src/c/common.h
@@ -29,6 +29,10 @@
 // For implementations, see linux.h, macos.h, posix.h, win32.h
 // ===========================================================
 
+// used for calling XInitThreads on Linux/X11, empty on
+// Windows and macOS, defined in linux.h, win32.h, macos.h
+void initThreads();
+
 // run_command implementations in posix.h, win32.h
 int run_command(const char *command,
     const char *input[], size_t numInput,

--- a/src/c/linux.h
+++ b/src/c/linux.h
@@ -1,8 +1,27 @@
 #include <string.h>
+#include <dlfcn.h>
 
 #include "common.h"
 
 #define OS_NAME "linux"
+
+void (*xinit_threads_reference)();
+
+void initThreads() {
+    void *libX11Handle = dlopen("libX11.so", RTLD_LAZY);
+    if(libX11Handle != NULL) {
+        debug("Running XInitThreads\n");
+    	xinit_threads_reference = dlsym(libX11Handle, "XInitThreads");
+
+    	if(xinit_threads_reference != NULL) {
+    	    xinit_threads_reference();
+    	} else {
+    	    error("Could not find XInitThreads in X11 library: %s\n", dlerror());
+    	}
+    } else {
+        error("Could not find X11 library, not running XInitThreads.\n");
+    }
+}
 
 int is_command_available(const char *command) {
     return access(command, X_OK) == 0;

--- a/src/c/macos.h
+++ b/src/c/macos.h
@@ -7,6 +7,8 @@
 
 #define OS_NAME "macos"
 
+void initThreads() {}
+
 void show_alert(const char *title, const char *message) {
     /* TODO: Get this objc code working.
     // Create an NSString from the C string

--- a/src/c/win32.h
+++ b/src/c/win32.h
@@ -6,6 +6,8 @@
 #define SLASH "\\"
 #define EXE_SUFFIX ".exe"
 
+void initThreads() {}
+
 void *loadlib(const char *path) { return LoadLibrary(path); }
 void *dlsym(void *library, const char *symbol) { return GetProcAddress(library, symbol); }
 void dlclose(void *library) { FreeLibrary(library); }


### PR DESCRIPTION
Add initThreads() function, being empty on Windows and macOS, and executing XInitThreads() on Linux/X11