### PR TITLE
When in debug mode, log also to a file

### DIFF
--- a/src/commonMain/kotlin/file.kt
+++ b/src/commonMain/kotlin/file.kt
@@ -16,6 +16,7 @@ expect class File(rawPath: String) {
     val length : Long
     fun ls(): List<File>
     fun lines(): List<String>
+    fun write(s: String)
     fun mv(dest:File): Boolean
     fun rm() : Boolean
     fun rmdir() : Boolean

--- a/src/commonMain/kotlin/logging.kt
+++ b/src/commonMain/kotlin/logging.kt
@@ -5,6 +5,9 @@ import platform.posix.exit
 private const val EXIT_CODE_ON_FAIL = 20
 
 var debugMode = getenv("DEBUG") !in listOf(null, "", "0", "false", "FALSE")
+var logFilePath = getenv("JAUNCH_LOGFILE") ?: "jaunch.log"
+
+private var logFile: File? = null
 
 fun debug(vararg args: Any) { if (debugMode) report("DEBUG", *args) }
 
@@ -37,8 +40,18 @@ fun fail(message: String): Nothing {
 }
 
 private fun report(prefix: String, vararg args: Any) {
-    printlnErr(buildString {
+    val s = buildString {
         append("[$prefix] ")
         args.forEach { append(it) }
-    })
+    }
+    printlnErr(s)
+    if (debugMode) {
+        val log = logFile ?: File(logFilePath)
+        if (logFile == null) {
+            // Overwrite any log file from previous run.
+            if (log.exists) log.rm()
+            logFile = log
+        }
+        log.write("$s$NL")
+    }
 }

--- a/src/commonMain/kotlin/main.kt
+++ b/src/commonMain/kotlin/main.kt
@@ -110,6 +110,8 @@ fun main(args: Array<String>) {
 
     // Finally, execute all the directives! \^_^/
     executeDirectives(nonGlobalDirectives, launchDirectives, runtimes, argsInContext)
+
+    debugBanner("JAUNCH CONFIGURATION COMPLETE")
 }
 
 // -- Program flow functions --
@@ -126,6 +128,11 @@ private fun parseArguments(args: Array<String>): Pair<File?, List<String>> {
 
     // Enable debug mode when --debug flag is present.
     debugMode = inputArgs.contains("--debug")
+
+    // Note: We need to let parseArguments set the debugMode
+    // flag in response to the --debug argument being passed.
+    // So we wait until now to emit this initial debugging bookend message.
+    debugBanner("PROCEEDING WITH JAUNCH CONFIGURATION")
 
     debug("executable -> ", executable ?: "<null>")
     debug("inputArgs -> ", inputArgs)

--- a/src/commonMain/kotlin/main.kt
+++ b/src/commonMain/kotlin/main.kt
@@ -109,8 +109,7 @@ fun main(args: Array<String>) {
     }
 
     // Finally, execute all the directives! \^_^/
-    executeDirectives(nonGlobalDirectives, launchDirectives, runtimes, userArgs,
-        argsInContext)
+    executeDirectives(nonGlobalDirectives, launchDirectives, runtimes, argsInContext)
 }
 
 // -- Program flow functions --
@@ -531,7 +530,6 @@ private fun executeDirectives(
     configDirectives: List<String>,
     launchDirectives: List<String>,
     runtimes: List<RuntimeConfig>,
-    userArgs: ProgramArgs,
     argsInContext: Map<String, ProgramArgs>
 ) {
     debugBanner("EXECUTING DIRECTIVES")

--- a/src/posixMain/kotlin/file.kt
+++ b/src/posixMain/kotlin/file.kt
@@ -70,10 +70,6 @@ actual class File actual constructor(private val rawPath: String) {
         return lines
     }
 
-    override fun toString(): String {
-        return path
-    }
-
     @OptIn(ExperimentalForeignApi::class)
     actual fun mv(dest: File): Boolean {
         memScoped {
@@ -93,6 +89,10 @@ actual class File actual constructor(private val rawPath: String) {
         memScoped {
             return rmdir(path) == 0
         }
+    }
+
+    override fun toString(): String {
+        return path
     }
 }
 

--- a/src/posixMain/kotlin/file.kt
+++ b/src/posixMain/kotlin/file.kt
@@ -71,6 +71,18 @@ actual class File actual constructor(private val rawPath: String) {
     }
 
     @OptIn(ExperimentalForeignApi::class)
+    actual fun write(s: String) {
+        val file = fopen(path, "a") ?:
+            throw RuntimeException("Failed to open file: $this")
+        try {
+            fputs(s, file)
+        }
+        finally {
+            fclose(file)
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
     actual fun mv(dest: File): Boolean {
         memScoped {
             return rename(path, dest.path) == 0

--- a/src/posixMain/kotlin/file.kt
+++ b/src/posixMain/kotlin/file.kt
@@ -34,7 +34,7 @@ actual class File actual constructor(private val rawPath: String) {
     actual fun ls(): List<File> {
         if (!isDirectory) throw IllegalArgumentException("Not a directory: $path")
 
-        val directory = opendir(path) ?: throw IllegalArgumentException("Failed to open directory")
+        val directory = opendir(path) ?: throw IllegalArgumentException("Failed to open directory: $path")
         val files = mutableListOf<File>()
 
         try {
@@ -55,7 +55,7 @@ actual class File actual constructor(private val rawPath: String) {
     actual fun lines(): List<String> {
         val lines = mutableListOf<String>()
         memScoped {
-            val file = fopen(path, "r") ?: throw RuntimeException("Failed to open file")
+            val file = fopen(path, "r") ?: throw RuntimeException("Failed to open file: $this")
             try {
                 while (true) {
                     val buffer = ByteArray(BUFFER_SIZE)

--- a/src/windowsMain/kotlin/file.kt
+++ b/src/windowsMain/kotlin/file.kt
@@ -19,7 +19,9 @@ actual class File actual constructor(private val rawPath: String) {
 
     actual val isRoot: Boolean =
         // Is it a drive letter plus backslash (e.g. `C:\`)?
-        path.length == 3 && (path[0] in 'a'..'z' || path[0] in 'A'..'Z') && path[1] == ':' && path[2] == '\\'
+        path.length == 3 &&
+          (path[0] in 'a'..'z' || path[0] in 'A'..'Z') &&
+          path[1] == ':' && path[2] == '\\'
 
     @OptIn(ExperimentalForeignApi::class)
     actual val length: Long get() {

--- a/src/windowsMain/kotlin/file.kt
+++ b/src/windowsMain/kotlin/file.kt
@@ -94,10 +94,6 @@ actual class File actual constructor(private val rawPath: String) {
         return lines
     }
 
-    override fun toString(): String {
-        return path
-    }
-
     @OptIn(ExperimentalForeignApi::class)
     actual fun mv(dest: File): Boolean {
         memScoped {
@@ -120,6 +116,10 @@ actual class File actual constructor(private val rawPath: String) {
         memScoped {
             return RemoveDirectoryW(path) != 0
         }
+    }
+
+    override fun toString(): String {
+        return path
     }
 
     private fun isMode(modeBits: Int): Boolean {


### PR DESCRIPTION
Now, when passing `--debug` to Jaunch, the configurator program will open a log file (default `jaunch.log` in the CWD; overrideable via the `JAUNCH_LOGFILE` environment variable) and write the same things there that it does to stderr. This may be especially helpful on Windows, due to the complexity of its various console programs (CMD.EXE, PowerShell, MSYS/Git bash, etc.), where in some scenarios a console may pop and close again after a split second before most humans are able to read the output.

Fixes #60.