### PR TITLE
Minor edits to docs

### DIFF
--- a/configs/common.toml
+++ b/configs/common.toml
@@ -19,9 +19,9 @@
 # overrides or augments this configuration with fizzbuzz-specific settings.
 #
 # For simple examples of specific applications, see:
-# - app/jaunch/paunch.toml - Paunch, a Jaunch-based Python launcher
-# - app/jaunch/jy.toml     - Jy, a Jaunch-based Jython launcher
-# - app/jaunch/parsy.toml  - Parsy, a launcher for the Parsington library.
+# - paunch.toml - Paunch, a Jaunch-based Python launcher
+# - jy.toml     - Jy, a Jaunch-based Jython launcher
+# - parsy.toml  - Parsy, a launcher for the Parsington library.
 #
 # Alternately, if you would like to keep all configuration together in one file
 # for simplicity, you can write a single TOML file with everything, and name it

--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -13,7 +13,7 @@
 3. Fire up a POSIX-friendly shell like zsh or bash.
    * On Linux and macOS, the built-in Terminal app will do the trick.
    * On Windows, use [Git Bash](https://gitforwindows.org/), which we
-     recommend installing via [Scoop](https://scoop.sh/).
+     recommend installing via [Scoop](https://scoop.sh/) (`scoop install git`).
 
 4. Create a directory to serve as your application's base directory.
    For example, if your application is called Fizzbuzz, you might do:
@@ -26,8 +26,12 @@
 5. Create a `fizzbuzz.toml` file matching your app's launch requirements.
 
    - To gain an understanding of the various configuration options,
-     read through `~/jaunch-1.0.2/jaunch/common.toml`, and perhaps
-     also `python.toml` and `jvm.toml`.
+     read through
+     [`common.toml`](https://github.com/apposed/jaunch/tree/main/configs/common.toml),
+     and perhaps also
+     [`python.toml`](https://github.com/apposed/jaunch/tree/main/configs/python.toml)
+     and
+     [`jvm.toml`](https://github.com/apposed/jaunch/tree/main/configs/jvm.toml).
 
    - If you are in a hurry, check out some example app configurations
      [here](https://github.com/apposed/jaunch/tree/main/configs).


### PR DESCRIPTION
- Remove obsolete(?) path from example toml files mentioned in common.toml.
- Add command for installing Git for Windows via scoop (people may otherwise look for a package named like git-bash, or so I thought).
- Add hyperlinks to config files.